### PR TITLE
Manual migration to androidx/target sdk 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,16 +22,16 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'
     }
 }
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 }

--- a/android/src/main/java/co/medcorder/medcorderaudio/MedcorderAudioPlugin.java
+++ b/android/src/main/java/co/medcorder/medcorderaudio/MedcorderAudioPlugin.java
@@ -8,7 +8,7 @@ import android.media.MediaPlayer;
 import android.media.MediaRecorder;
 import android.net.Uri;
 import android.util.Log;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 
 import java.io.File;
 import java.util.HashMap;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -38,7 +38,7 @@ android {
         targetSdkVersion 27
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -56,6 +56,6 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 }


### PR DESCRIPTION
This may be useful now or later - it seems like this androidx stuff will replace android.support - though it seems like you can't mix&match.

I haven't looked that much into this yet - but it seems like it would make sense for plugins to have dual support (a migrated vs unmigrated version) so you don't end up in version hell - one way for this can obviously just be using old versions of plugins if you're not ready to migrate your flutter app to androidx.  This seems to be what flutter is favoring.

See:
Flutter migration: https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility
Android migration: https://developer.android.com/jetpack/androidx/migrate